### PR TITLE
Make reset params consistent, fix errors in Javadocs, fix styling issues

### DIFF
--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/AbstractPaperItemBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/AbstractPaperItemBuilder.java
@@ -71,7 +71,7 @@ public abstract class AbstractPaperItemBuilder<B extends AbstractPaperItemBuilde
     }
 
     /**
-     * Sets the lore. Pass {@code List.of()} to reset.
+     * Sets the lore. Pass {@code null} to reset.
      * <p>
      * Each component passed in is appended to an empty component decorated with
      * italicization set to false. This effectively bypasses the default,

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/ArmorStandBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/ArmorStandBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import com.destroystokyo.paper.inventory.meta.ArmorStandMeta;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/AxolotlBucketBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/AxolotlBucketBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.entity.Axolotl;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BannerBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BannerBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BlockDataBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BlockDataBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BlockStateBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BlockStateBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BookBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BookBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -118,13 +117,18 @@ public final class BookBuilder extends AbstractPaperItemBuilder<BookBuilder, Boo
     }
 
     /**
-     * Sets the pages. Pass {@code List.of()} to reset.
+     * Sets the pages. Pass {@code null} to reset.
      *
      * @param pages the pages
      * @return the builder
      */
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public @NonNull BookBuilder pages(final @NonNull List<@NonNull Component> pages) {
+    public @NonNull BookBuilder pages(final @Nullable List<@NonNull Component> pages) {
+        if (pages == null) {
+            this.itemMeta.pages(List.of());
+            return this;
+        }
+
         // in Paper's implementation, this will actually mutate the internal BookMeta instance
         // you can see the discussion I had about this on the Paper discord
         // https://canary.discord.com/channels/289587909051416579/555462289851940864/872168673283043328

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BundleBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/BundleBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BundleMeta;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/CompassBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/CompassBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/CrossbowBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/CrossbowBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.CrossbowMeta;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/EnchantmentStorageBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/EnchantmentStorageBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/FireworkBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/FireworkBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/FireworkEffectBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/FireworkEffectBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/KnowledgeBookBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/KnowledgeBookBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/LeatherArmorBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/LeatherArmorBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/MapBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/MapBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -44,7 +43,7 @@ public final class MapBuilder extends AbstractPaperItemBuilder<MapBuilder, MapMe
     }
 
     /**
-     * Gets the {@code Color}. Pass {@code null} to clear.
+     * Gets the {@code Color}.
      *
      * @return the {@code Color}
      */

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/PotionBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/PotionBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/SkullBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/SkullBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
 import org.bukkit.Bukkit;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/SuspiciousStewBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/SuspiciousStewBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SuspiciousStewMeta;

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/TropicalFishBucketBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/TropicalFishBucketBuilder.java
@@ -1,7 +1,6 @@
 package broccolai.corn.paper.item.special;
 
 import broccolai.corn.paper.item.AbstractPaperItemBuilder;
-
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.entity.TropicalFish;

--- a/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractItemBuilder.java
+++ b/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractItemBuilder.java
@@ -47,6 +47,43 @@ public abstract class AbstractItemBuilder<B extends AbstractItemBuilder<B, M>, M
     }
 
     /**
+     * Attempts to cast {@code meta} to {@code expectedType},
+     * and returns the result if successful.
+     *
+     * @param meta         the meta
+     * @param expectedType the class of the expected type
+     * @param <T>          the expected type
+     * @return {@code meta} casted to {@code expectedType}
+     * @throws IllegalArgumentException if {@code} meta is not the type of {@code expectedType}
+     */
+    protected static <T extends ItemMeta> T castMeta(final ItemMeta meta, final Class<T> expectedType)
+            throws IllegalArgumentException {
+        try {
+            return expectedType.cast(meta);
+        } catch (final ClassCastException e) {
+            throw new IllegalArgumentException("The ItemMeta must be of type "
+                    + expectedType.getSimpleName()
+                    + " but received ItemMeta of type "
+                    + meta.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Returns an {@code ItemStack} of {@code material} if it is an item,
+     * else throws an exception.
+     *
+     * @param material the material
+     * @return an {@code ItemStack} of type {@code material}
+     * @throws IllegalArgumentException if {@code material} is not an item
+     */
+    protected static @NonNull ItemStack getItem(final @NonNull Material material) throws IllegalArgumentException {
+        if (!material.isItem()) {
+            throw new IllegalArgumentException("The Material must be an obtainable item.");
+        }
+        return new ItemStack(material);
+    }
+
+    /**
      * Gets the {@code Material}.
      *
      * @return the {@code Material}
@@ -233,7 +270,7 @@ public abstract class AbstractItemBuilder<B extends AbstractItemBuilder<B, M>, M
     }
 
     /**
-     * Sets the custom model data. Pass {@code null} to clear.
+     * Sets the custom model data. Pass {@code null} to reset.
      *
      * @param customModelData the custom model data
      * @return the builder
@@ -334,43 +371,6 @@ public abstract class AbstractItemBuilder<B extends AbstractItemBuilder<B, M>, M
     public @NonNull ItemStack build() {
         this.itemStack.setItemMeta(this.itemMeta);
         return this.itemStack.clone();
-    }
-
-    /**
-     * Attempts to cast {@code meta} to {@code expectedType},
-     * and returns the result if successful.
-     *
-     * @param meta         the meta
-     * @param expectedType the class of the expected type
-     * @param <T>          the expected type
-     * @return {@code meta} casted to {@code expectedType}
-     * @throws IllegalArgumentException if {@code} meta is not the type of {@code expectedType}
-     */
-    protected static <T extends ItemMeta> T castMeta(final ItemMeta meta, final Class<T> expectedType)
-            throws IllegalArgumentException {
-        try {
-            return expectedType.cast(meta);
-        } catch (final ClassCastException e) {
-            throw new IllegalArgumentException("The ItemMeta must be of type "
-                    + expectedType.getSimpleName()
-                    + " but received ItemMeta of type "
-                    + meta.getClass().getSimpleName());
-        }
-    }
-
-    /**
-     * Returns an {@code ItemStack} of {@code material} if it is an item,
-     * else throws an exception.
-     *
-     * @param material the material
-     * @return an {@code ItemStack} of type {@code material}
-     * @throws IllegalArgumentException if {@code material} is not an item
-     */
-    protected static @NonNull ItemStack getItem(final @NonNull Material material) throws IllegalArgumentException {
-        if (!material.isItem()) {
-            throw new IllegalArgumentException("The Material must be an obtainable item.");
-        }
-        return new ItemStack(material);
     }
 
 }

--- a/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractSpigotItemBuilder.java
+++ b/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractSpigotItemBuilder.java
@@ -54,7 +54,7 @@ public abstract class AbstractSpigotItemBuilder<B extends AbstractSpigotItemBuil
     }
 
     /**
-     * Sets the lore. Pass {@code List.of()} to reset.
+     * Sets the lore. Pass {@code null} to reset.
      *
      * @param lines the lines of the lore
      * @return the builder


### PR DESCRIPTION
The commit message explains it pretty well:
```
Reset pages if BookBuilder#pages is passed null

Additionally:
- fix import style
- jd: remove accident in MapBuilder#color()
- jd: label AbstractPaperItemBuilder#lore reset param correctly
- reorder AbstractItemBuilder static methods
- jd: make AbstractItemBuilder#customModelData reset param instruction consistent with others
- jd: label AbstractSpigotItemBuilder#lore reset param correctly
```