### PR TITLE
feat?: remove Abstract*ItemBuilder lore varargs setter

### DIFF
--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/AbstractPaperItemBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/AbstractPaperItemBuilder.java
@@ -98,17 +98,6 @@ public abstract class AbstractPaperItemBuilder<B extends AbstractPaperItemBuilde
     /**
      * Sets the lore.
      *
-     * @param lines the lines of the lore
-     * @return the builder
-     */
-    public @NonNull B lore(final @Nullable Component... lines) {
-        this.lore(List.of(lines));
-        return (B) this;
-    }
-
-    /**
-     * Sets the lore.
-     *
      * @param consumer the lines of the lore
      * @return the builder
      */

--- a/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractSpigotItemBuilder.java
+++ b/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractSpigotItemBuilder.java
@@ -67,17 +67,6 @@ public abstract class AbstractSpigotItemBuilder<B extends AbstractSpigotItemBuil
     /**
      * Sets the lore.
      *
-     * @param lines the lines of the lore
-     * @return the builder
-     */
-    public @NonNull B lore(final @Nullable String... lines) {
-        this.lore(List.of(lines));
-        return (B) this;
-    }
-
-    /**
-     * Sets the lore.
-     *
      * @param consumer the lines of the lore
      * @return the builder
      */


### PR DESCRIPTION
This pull request removes a feature that some folks could want to keep, so I'm marking it as a draft until this design decision is discussed a bit.

On one hand, having a varargs setter for lore is beneficial because it saves developers from needing to type `List.of` every time they want to add lore to an item, which is a very common operation.

On the other hand, `List.of` is not difficult to type out and doesn't clutter up code very much. Additionally, _no other_ field setter method in corn's item builders has a varargs overload, so this specific case is unusual and can easily be removed. Most importantly, this method prevents users from being able to unambiguously pass `null` into `#lore` to clear the lore, forcing them to pass in an empty list (`List.of()`) instead. This creates a frustrating API inconsistency.

I personally think the method should be removed, because I value API consistency over a small helper method (literally a `List.of` wrapper for `#lore`).

Looking for feedback.