### PR TITLE
rename ItemBuilder#lore(Consumer) to #loreModifier

### DIFF
--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/AbstractPaperItemBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/AbstractPaperItemBuilder.java
@@ -96,13 +96,15 @@ public abstract class AbstractPaperItemBuilder<B extends AbstractPaperItemBuilde
     }
 
     /**
-     * Sets the lore.
+     * Directly modifies the lore with a {@link Consumer}.
+     * If the item has no lore, an empty {@code List} will
+     * be supplied to the {@code Consumer} instead.
      *
-     * @param consumer the lines of the lore
+     * @param consumer the {@code Consumer} to modify the lore with
      * @return the builder
      */
-    public @NonNull B lore(final @NonNull Consumer<List<Component>> consumer) {
-        final @NonNull List<@NonNull Component> lore = Optional
+    public @NonNull B loreModifier(final @NonNull Consumer<@NonNull List<Component>> consumer) {
+        final @NonNull List<Component> lore = Optional
                 .ofNullable(this.itemMeta.lore())
                 .orElse(new ArrayList<>());
 

--- a/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractSpigotItemBuilder.java
+++ b/minecraft/spigot/src/main/java/broccolai/corn/spigot/item/AbstractSpigotItemBuilder.java
@@ -65,13 +65,15 @@ public abstract class AbstractSpigotItemBuilder<B extends AbstractSpigotItemBuil
     }
 
     /**
-     * Sets the lore.
+     * Directly modifies the lore with a {@link Consumer}.
+     * If the item has no lore, an empty {@code List} will
+     * be supplied to the {@code Consumer} instead.
      *
-     * @param consumer the lines of the lore
+     * @param consumer the {@code Consumer} to modify the lore with
      * @return the builder
      */
-    public @NonNull B lore(final @NonNull Consumer<List<String>> consumer) {
-        final @NonNull List<@NonNull String> lore = Optional
+    public @NonNull B loreModifier(final @NonNull Consumer<@NonNull List<String>> consumer) {
+        final @NonNull List<String> lore = Optional
                 .ofNullable(this.itemMeta.getLore())
                 .orElse(new ArrayList<>());
 


### PR DESCRIPTION
This change is mainly to avoid ambiguity when passing null to #lore(List), but the name is also more explanatory of what the method actually does.