### PR TITLE
feat: add RepairableBuilder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,8 @@ subprojects {
         checkstyle("9.0")
 
         javaVersions {
-            target(16)
-            testWith(16)
+            target(17)
+            testWith(17)
         }
 
         github("broccolai", "corn") {

--- a/gradle/libs.versions.conf
+++ b/gradle/libs.versions.conf
@@ -20,8 +20,8 @@ versions = {
   junit = "5.7.1"
 
   adventure-api = "4.7.0"
-  spigot-api = "1.17.1-R0.1-SNAPSHOT"
-  paper-api = "1.17.1-R0.1-SNAPSHOT"
+  spigot-api = "1.18.1-R0.1-SNAPSHOT"
+  paper-api = "1.18.1-R0.1-SNAPSHOT"
   geantyref = "1.3.11"
 }
 

--- a/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/RepairableBuilder.java
+++ b/minecraft/paper/src/main/java/broccolai/corn/paper/item/special/RepairableBuilder.java
@@ -1,0 +1,66 @@
+package broccolai.corn.paper.item.special;
+
+import broccolai.corn.paper.item.AbstractPaperItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Repairable;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Modifies {@link ItemStack}s that have an {@code ItemMeta} of {@link Repairable}.
+ */
+@SuppressWarnings("unused")
+public final class RepairableBuilder extends AbstractPaperItemBuilder<RepairableBuilder, Repairable> {
+
+    private RepairableBuilder(final @NonNull ItemStack itemStack, final @NonNull Repairable itemMeta) {
+        super(itemStack, itemMeta);
+    }
+
+    /**
+     * Creates an {@code RepairableBuilder}.
+     *
+     * @param itemStack the {@code ItemStack} to base the builder off of
+     * @return instance of {@code RepairableBuilder}
+     * @throws IllegalArgumentException if the {@code itemStack}'s {@code ItemMeta} is not the correct type
+     */
+    public static @NonNull RepairableBuilder of(final @NonNull ItemStack itemStack) throws IllegalArgumentException {
+        return new RepairableBuilder(itemStack, castMeta(itemStack.getItemMeta(), Repairable.class));
+    }
+
+    /**
+     * Creates an {@code RepairableBuilder}.
+     *
+     * @param material the {@code Material} to base the builder off of
+     * @return instance of {@code RepairableBuilder}
+     * @throws IllegalArgumentException if the {@code material} is not an obtainable item,
+     *                                  or if the {@code material}'s {@code ItemMeta} is not the correct type
+     */
+    public static @NonNull RepairableBuilder ofType(final @NonNull Material material) throws IllegalArgumentException {
+        return RepairableBuilder.of(getItem(material));
+    }
+
+    /**
+     * Gets the repair cost.
+     *
+     * @return the repair cost
+     */
+    public @Nullable Integer repairCost() {
+        if (this.itemMeta.hasRepairCost()) {
+            return null;
+        }
+        return this.itemMeta.getRepairCost();
+    }
+
+    /**
+     * Sets the repair cost.
+     *
+     * @param repairCost the repair cost
+     * @return the builder
+     */
+    public @NonNull RepairableBuilder repairCost(final @NonNull Integer repairCost) {
+        this.itemMeta.setRepairCost(repairCost);
+        return this;
+    }
+
+}


### PR DESCRIPTION
Build is currently failing because `Repairable` doesn't extend `ItemMeta`. A pr to Spigot has already been made to fix this, so we're blocked only by https://github.com/PaperMC/Paper/pull/7359. Once that's merged, this issue's build can be rerun to verify the build.